### PR TITLE
fix uri encoding bug, when use dbresource:// uri in xsl-fo file, if filename is not ascii, resource not found.

### DIFF
--- a/src/main/groovy/org/moqui/fop/FopToolFactory.groovy
+++ b/src/main/groovy/org/moqui/fop/FopToolFactory.groovy
@@ -98,7 +98,7 @@ class FopToolFactory implements ToolFactory<org.xml.sax.ContentHandler> {
         }
 
         public OutputStream getOutputStream(URI uri) throws IOException {
-            ResourceReference rr = ecf.getResource().getLocationReference(uri.toASCIIString())
+            ResourceReference rr = ecf.getResource().getLocationReference(uri.toString())
             if (rr != null) {
                 OutputStream os = rr.getOutputStream()
                 if (os != null) return os
@@ -108,7 +108,7 @@ class FopToolFactory implements ToolFactory<org.xml.sax.ContentHandler> {
         }
 
         public Resource getResource(URI uri) throws IOException {
-            ResourceReference rr = ecf.getResource().getLocationReference(uri.toASCIIString())
+            ResourceReference rr = ecf.getResource().getLocationReference(uri.toString())
             if (rr != null) {
                 InputStream is = rr.openStream()
                 if (is != null) return new Resource(is)


### PR DESCRIPTION
I don't known the reason of using toASCIIString, so this patch may break some function. Please review this PR.

In my case, the filename contains unicode chars. when using toASCIIString the filename encoded as `%dd%dd%dd.pdf` which can not found in DB. other method like `sendResourceResponse` pass the location as is to `ResourceFacade`.